### PR TITLE
Datetime locale

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,3 +3,4 @@ SECRET = "secret"
 BASE_URL = "http://localhost:8000"
 AUTH_TEST = "testuser"
 UPLOAD_FOLDER = "/tmp"
+LOCALE = 'en_US'

--- a/src/lobo2/__init__.py
+++ b/src/lobo2/__init__.py
@@ -519,7 +519,7 @@ def _format_datetime(value, fmt='medium'):
         fmt = "EEEE, d. MMMM y 'at' HH:mm"
     elif fmt == 'medium':
         fmt = "EE dd.MM.y HH:mm"
-    return format_datetime(value, fmt. locale=locale)
+    return format_datetime(value, fmt, locale=locale)
 
 
 @app.template_filter("path_to_file")

--- a/src/lobo2/__init__.py
+++ b/src/lobo2/__init__.py
@@ -514,11 +514,12 @@ def error(e):
 
 @app.template_filter("strftime")
 def _format_datetime(value, fmt='medium'):
+    locale = app.config.get('LOCALE', 'en_US')
     if fmt == 'full':
         fmt = "EEEE, d. MMMM y 'at' HH:mm"
     elif fmt == 'medium':
         fmt = "EE dd.MM.y HH:mm"
-    return format_datetime(value, fmt)
+    return format_datetime(value, fmt. locale=locale)
 
 
 @app.template_filter("path_to_file")


### PR DESCRIPTION
Had an issue with babel giving an AttributeError exception related to "locale" in the from_datetime method.

It may be that babel isn't properly detecting my systems locale (I didn't look into it that much), however I added a configuration option (LOCALE = "sv_SE") to config.py and set a default in the _from_datetime method to "en_US" if no LOCALE option is present in the config.